### PR TITLE
[FIGMA] Design tokens updated 16/01/2023 - 10:35:39

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opositatest/aperta-tokens",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opositatest/aperta-tokens",
-      "version": "1.0.0",
+      "version": "1.0.4",
       "license": "UNLICENSED",
       "devDependencies": {
         "axios": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opositatest/aperta-tokens",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "OpositaTest (https://opositatest.com/)",
   "type": "module",
   "license": "UNLICENSED",


### PR DESCRIPTION
Se han actualizado los Design Tokens desde Figma

**Recuerda actualizar la versión del [package.json][1]**

[1]: https://github.com/opositatest/aperta-tokens/blob/main/package.json