### PR TITLE
[TS] Script to rename icons mask

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opositatest/aperta-tokens",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "author": "OpositaTest (https://opositatest.com/)",
   "license": "UNLICENSED",
   "description": "OpositaTest Design System tokens",
@@ -20,8 +20,8 @@
   ],
   "scripts": {
     "package:download-svgs": "node ./scripts/download-svgs.js",
-    "package:minify-all-svgs": "node ./scripts/minify-svgs.js -folder",
-    "package:minify-changed-svgs": "node ./scripts/minify-svgs.js",
+    "package:minify-all-svgs": "node ./scripts/minify-svgs.js -folder && node ./scripts/rename-mask.js",
+    "package:minify-changed-svgs": "node ./scripts/minify-svgs.js && node ./scripts/rename-mask.js",
     "package:process-tokens": "node ./scripts/process-tokens.js",
     "package:style-dictionary": "style-dictionary build -c ./scripts/style-dictionary.js",
     "package:prepare": "node ./scripts/prepare-distribution.js"

--- a/scripts/minify-svgs.js
+++ b/scripts/minify-svgs.js
@@ -385,7 +385,7 @@ const readIcons = (directory, icons) => {
 
   icons = icons || [];
 
-  files.forEach(function (file) {
+  files.forEach((file) => {
     if (fs.statSync(`${directory}/${file}`).isDirectory()) {
       icons = readIcons(directory + file, icons);
     } else {

--- a/scripts/rename-mask.js
+++ b/scripts/rename-mask.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+
+const SRC_FOLDER = './dist/icons/';
+
+const renameMask = (file) => {
+  const svgContent = fs.readFileSync(file, 'utf8');
+  const maskRandom = Math.floor(Math.random() * 99999999);
+  console.log(
+    svgContent
+      .split('mask id="a"')
+      .join(`mask id="opo-mask-${maskRandom}"`)
+      .split('mask="url(#a)"')
+      .join(`mask="url(#opo-mask-${maskRandom})"`),
+  );
+  fs.writeFileSync(
+    file,
+    svgContent
+      .split('mask id="a"')
+      .join(`mask id="opo-mask-${maskRandom}"`)
+      .split('mask="url(#a)"')
+      .join(`mask="url(#opo-mask-${maskRandom})"`),
+  );
+};
+
+const readIcons = (directory) => {
+  const files = fs.readdirSync(directory);
+
+  files.forEach((file) => {
+    if (file !== 'icons.ts') {
+      if (fs.statSync(`${directory}/${file}`).isDirectory()) {
+        readIcons(directory + file);
+      } else {
+        renameMask(`${directory}/${file}`);
+      }
+    }
+  });
+};
+
+readIcons(SRC_FOLDER);


### PR DESCRIPTION
## Referencias
- Kanbanflow: [[APERTA] Nuevos iconos en foundations](https://kanbanflow.com/t/PV6u661u)

## Lista de comprobación
- [ ] Se incluyen test que validan los [criterios de aceptación](https://userwell.com/acceptance-criteria-types-and-tips) y/o corrección propuesta.
- [ ] Se han creado tareas en Kanbanflow para los puntos que queden pendientes o que no se harán en esta PR.
- [X] El título de la PR sigue el [estándar de etiquetado](https://github.com/opositatest/standards/blob/master/vcs/git.md#pull-request).

## Qué se hizo
- Se añade un script para renombrar las mask de los svgs y evitar así que se sobreescriban los iconos al mostrarse en pantalla